### PR TITLE
Make put_response_hop_limit configurable on managers and workers.

### DIFF
--- a/managers.tf
+++ b/managers.tf
@@ -139,8 +139,9 @@ resource "aws_instance" "managers" {
   }
 
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = var.metadata_http_tokens_required ? "required" : "optional"
+    http_endpoint               = "enabled"
+    http_tokens                 = var.metadata_http_tokens_required ? "required" : "optional"
+    http_put_response_hop_limit = var.metadata_put_response_hop_limit
   }
 
   ebs_optimized = true

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable "metadata_http_tokens_required" {
   default     = false
 }
 
+variable "metadata_put_response_hop_limit" {
+  description = "Desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. Valid values are integer from 1 to 64."
+  default     = 1
+}
+
 variable "vpc_id" {
   description = "The VPC that will contain the swarm."
 }

--- a/workers.tf
+++ b/workers.tf
@@ -135,8 +135,9 @@ resource "aws_instance" "workers" {
   }
 
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = var.metadata_http_tokens_required ? "required" : "optional"
+    http_endpoint               = "enabled"
+    http_tokens                 = var.metadata_http_tokens_required ? "required" : "optional"
+    http_put_response_hop_limit = var.metadata_put_response_hop_limit
   }
 
   ebs_optimized = true


### PR DESCRIPTION
Issue: If IMDSv2 is set to 'required' containers using it might not get a reply because of the additional hop needed.
This way it can be parameterized.

